### PR TITLE
Fixing Submodule link to correct repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lancache"]
 	path = lancache
-	url = https://github.com/fhibler/lancache.git
+	url = https://github.com/bntjah/lancache.git

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ lancache installer script
 This script has been tested under Debian 8.6 amd64.
 
     1) git clone -b master --recursive http://github.com/bntjah/lc-installer/
-    3) cd lc-installer
-	2) chmod +x installer.sh
-	3) ./installer.sh
-	4) Reboot your system
+    2) cd lc-installer
+	3) chmod +x installer.sh
+	4) ./installer.sh
+	5) Reboot your system
 	
 Notes:
 


### PR DESCRIPTION
Fixed submodule to point to bntjah/lancache instead of the forked one.